### PR TITLE
Use output buffer to properly return shortcode template.

### DIFF
--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -45,6 +45,8 @@ function wpinstagram_images( $atts ){
     	}
     }
 
+    ob_start();
+
     _wpinstagram_template( 'shortcode_images' , array(
     	'images' => $images_to_show,
     	'target' => $target,
@@ -52,5 +54,8 @@ function wpinstagram_images( $atts ){
     	'width'  => $width,
     	'height' => $height
     ));
+
+    $output = ob_get_clean();
+    return $output;
 
 }


### PR DESCRIPTION
The plugin currently just echos the shortcode's template content to the page.  This will break placement of the shortcode in page text.  Output buffers should be used in the registered shortcode function to return the template content instead, as per Wordpress developer practice: http://codex.wordpress.org/Shortcode_API#Output
