### PR TITLE
Update InstagramCrawler.php

### DIFF
--- a/class/InstagramCrawler.php
+++ b/class/InstagramCrawler.php
@@ -84,7 +84,8 @@ class InstagramCrawler {
 
 		$response = wp_remote_get( $url,
 			array(
-				'timeout' => 60
+				'timeout' => 60,
+				'user-agent'  => 'WordPress/' . $wp_version . '; ',
 			)
 		);
 


### PR DESCRIPTION
Seems like Instagram is serving different content by domain request. Maybe they're testing A/B or sth like that. 
Without specifying user-agent, in specific domains, the response obtained doesn't have the proper format as wp_remote_get takes the current domain as part of the default value for the user-agent variable ( 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) ).
Removing the get_bloginfo('url') part solves the problem.
